### PR TITLE
Generalize Time and Frequency Domain Annotations

### DIFF
--- a/scos_actions/actions/acquire_single_freq_fft.py
+++ b/scos_actions/actions/acquire_single_freq_fft.py
@@ -252,6 +252,9 @@ class SingleFrequencyFftAcquisition(MeasurementAction):
                 nffts=self.nffts,
                 units="dBm",
                 reference="preselector input",
+                frequency_start=measurement_result["frequency_start"],
+                frequency_stop=measurement_result["frequency_stop"],
+                frequency_step=measurement_result["frequency_step"],
             )
             sigmf_builder.add_metadata_generator(
                 type(fft_annotation).__name__ + "_" + detector.value, fft_annotation

--- a/scos_actions/actions/acquire_single_freq_fft.py
+++ b/scos_actions/actions/acquire_single_freq_fft.py
@@ -87,16 +87,8 @@ The resulting matrix is real-valued, 32-bit floats representing dBm.
 """
 
 import logging
-
-from numpy import float32, ndarray
-
 from scos_actions import utils
 from scos_actions.actions.interfaces.measurement_action import MeasurementAction
-from scos_actions.hardware import gps as mock_gps
-from scos_actions.metadata.annotations.fft_annotation import (
-    FrequencyDomainDetectionAnnotation,
-)
-from scos_actions.metadata.sigmf_builder import Domain, MeasurementType, SigMFBuilder
 from scos_actions.signal_processing.fft import (
     get_fft,
     get_fft_enbw,
@@ -104,16 +96,18 @@ from scos_actions.signal_processing.fft import (
     get_fft_window,
     get_fft_window_correction,
 )
+from scos_actions.metadata.sigmf_builder import Domain, MeasurementType, SigMFBuilder
+from scos_actions.metadata.annotations.fft_annotation import FrequencyDomainDetectionAnnotation
+from scos_actions.hardware import gps as mock_gps
+
+from scos_actions.utils import get_parameter
 from scos_actions.signal_processing.power_analysis import (
     apply_power_detector,
     calculate_power_watts,
     create_power_detector,
 )
-from scos_actions.signal_processing.unit_conversion import (
-    convert_linear_to_dB,
-    convert_watts_to_dBm,
-)
-from scos_actions.utils import get_parameter
+from scos_actions.signal_processing.unit_conversion import convert_watts_to_dBm, convert_linear_to_dB
+from numpy import float32, ndarray
 
 logger = logging.getLogger(__name__)
 
@@ -170,26 +164,25 @@ class SingleFrequencyFftAcquisition(MeasurementAction):
         m4s_result = self.apply_m4s(measurement_result)
 
         # Save measurement results
-        measurement_result["data"] = m4s_result
-        measurement_result["start_time"] = start_time
-        measurement_result["end_time"] = utils.get_datetime_str_now()
-        measurement_result["enbw"] = get_fft_enbw(self.fft_window, sample_rate_Hz)
+        measurement_result['data'] = m4s_result
+        measurement_result['start_time'] = start_time
+        measurement_result['end_time'] = utils.get_datetime_str_now()
+        measurement_result['enbw'] = get_fft_enbw(self.fft_window, sample_rate_Hz)
         frequencies = get_fft_frequencies(
             self.fft_size, sample_rate_Hz, self.frequency_Hz
         )
         measurement_result.update(self.parameters)
-        measurement_result["description"] = self.description
-        measurement_result["domain"] = Domain.FREQUENCY.value
-        measurement_result["frequency_start"] = frequencies[0]
-        measurement_result["frequency_stop"] = frequencies[-1]
-        measurement_result["frequency_step"] = frequencies[1] - frequencies[0]
-        measurement_result["calibration_datetime"] = self.sigan.sensor_calibration_data[
-            "calibration_datetime"
-        ]
-        measurement_result["task_id"] = task_id
-        measurement_result["measurement_type"] = MeasurementType.SINGLE_FREQUENCY.value
-        measurement_result["sigan_cal"] = self.sigan.sigan_calibration_data
-        measurement_result["sensor_cal"] = self.sigan.sensor_calibration_data
+        measurement_result['description'] = self.description
+        measurement_result['domain'] = Domain.FREQUENCY.value
+        measurement_result['frequency_start'] = frequencies[0]
+        measurement_result['frequency_stop'] = frequencies[-1]
+        measurement_result['frequency_step'] = frequencies[1] - frequencies[0]
+        measurement_result['window'] = self.fft_window_type
+        measurement_result['calibration_datetime'] = self.sigan.sensor_calibration_data['calibration_datetime']
+        measurement_result['task_id'] = task_id
+        measurement_result['measurement_type'] = MeasurementType.SINGLE_FREQUENCY.value
+        measurement_result['sigan_cal'] = self.sigan.sigan_calibration_data
+        measurement_result['sensor_cal'] = self.sigan.sensor_calibration_data
         return measurement_result
 
     def apply_m4s(self, measurement_result: dict) -> ndarray:
@@ -209,7 +202,7 @@ class SingleFrequencyFftAcquisition(MeasurementAction):
         #   RF/Baseband power conversion (-3 dB)
         #   FFT window amplitude correction
         m4s_result -= 3
-        m4s_result += 2.0 * convert_linear_to_dB(self.fft_window_acf)
+        m4s_result += 2. * convert_linear_to_dB(self.fft_window_acf)
         return m4s_result
 
     @property

--- a/scos_actions/actions/acquire_single_freq_tdomain_iq.py
+++ b/scos_actions/actions/acquire_single_freq_tdomain_iq.py
@@ -33,16 +33,13 @@ signals.
 
 import logging
 
-from numpy import complex64
-
 from scos_actions import utils
-from scos_actions.actions.interfaces.measurement_action import MeasurementAction
-from scos_actions.hardware import gps as mock_gps
-from scos_actions.metadata.annotations.time_domain_annotation import (
-    TimeDomainAnnotation,
-)
-from scos_actions.metadata.sigmf_builder import Domain, MeasurementType, SigMFBuilder
 from scos_actions.utils import get_parameter
+from scos_actions.actions.interfaces.measurement_action import MeasurementAction
+from scos_actions.metadata.sigmf_builder import Domain, MeasurementType, SigMFBuilder
+from scos_actions.hardware import gps as mock_gps
+from scos_actions.metadata.annotations.time_domain_annotation import TimeDomainAnnotation
+from numpy import complex64
 
 logger = logging.getLogger(__name__)
 
@@ -86,19 +83,17 @@ class SingleFrequencyTimeDomainIqAcquisition(MeasurementAction):
         sample_rate = self.sigan.sample_rate
         num_samples = int(sample_rate * self.duration_ms * 1e-3)
         measurement_result = self.acquire_data(num_samples, self.nskip)
-        measurement_result["start_time"] = start_time
+        measurement_result['start_time'] = start_time
         end_time = utils.get_datetime_str_now()
         measurement_result.update(self.parameters)
-        measurement_result["end_time"] = end_time
-        measurement_result["domain"] = Domain.TIME.value
-        measurement_result["measurement_type"] = MeasurementType.SINGLE_FREQUENCY.value
-        measurement_result["task_id"] = task_id
-        measurement_result["calibration_datetime"] = self.sigan.sensor_calibration_data[
-            "calibration_datetime"
-        ]
-        measurement_result["description"] = self.description
-        measurement_result["sigan_cal"] = self.sigan.sigan_calibration_data
-        measurement_result["sensor_cal"] = self.sigan.sensor_calibration_data
+        measurement_result['end_time'] = end_time
+        measurement_result['domain'] = Domain.TIME.value
+        measurement_result['measurement_type'] = MeasurementType.SINGLE_FREQUENCY.value
+        measurement_result['task_id'] = task_id
+        measurement_result['calibration_datetime'] = self.sigan.sensor_calibration_data['calibration_datetime']
+        measurement_result['description'] = self.description
+        measurement_result['sigan_cal'] = self.sigan.sigan_calibration_data
+        measurement_result['sensor_cal'] = self.sigan.sensor_calibration_data
         return measurement_result
 
     def get_sigmf_builder(self, measurement_result: dict) -> SigMFBuilder:
@@ -143,3 +138,7 @@ class SingleFrequencyTimeDomainIqAcquisition(MeasurementAction):
 
     def is_complex(self) -> bool:
         return True
+
+
+    
+

--- a/scos_actions/actions/acquire_single_freq_tdomain_iq.py
+++ b/scos_actions/actions/acquire_single_freq_tdomain_iq.py
@@ -33,13 +33,16 @@ signals.
 
 import logging
 
-from scos_actions import utils
-from scos_actions.utils import get_parameter
-from scos_actions.actions.interfaces.measurement_action import MeasurementAction
-from scos_actions.metadata.sigmf_builder import Domain, MeasurementType, SigMFBuilder
-from scos_actions.hardware import gps as mock_gps
-from scos_actions.metadata.annotations.time_domain_annotation import TimeDomainAnnotation
 from numpy import complex64
+
+from scos_actions import utils
+from scos_actions.actions.interfaces.measurement_action import MeasurementAction
+from scos_actions.hardware import gps as mock_gps
+from scos_actions.metadata.annotations.time_domain_annotation import (
+    TimeDomainAnnotation,
+)
+from scos_actions.metadata.sigmf_builder import Domain, MeasurementType, SigMFBuilder
+from scos_actions.utils import get_parameter
 
 logger = logging.getLogger(__name__)
 
@@ -83,22 +86,30 @@ class SingleFrequencyTimeDomainIqAcquisition(MeasurementAction):
         sample_rate = self.sigan.sample_rate
         num_samples = int(sample_rate * self.duration_ms * 1e-3)
         measurement_result = self.acquire_data(num_samples, self.nskip)
-        measurement_result['start_time'] = start_time
+        measurement_result["start_time"] = start_time
         end_time = utils.get_datetime_str_now()
         measurement_result.update(self.parameters)
-        measurement_result['end_time'] = end_time
-        measurement_result['domain'] = Domain.TIME.value
-        measurement_result['measurement_type'] = MeasurementType.SINGLE_FREQUENCY.value
-        measurement_result['task_id'] = task_id
-        measurement_result['calibration_datetime'] = self.sigan.sensor_calibration_data['calibration_datetime']
-        measurement_result['description'] = self.description
-        measurement_result['sigan_cal'] = self.sigan.sigan_calibration_data
-        measurement_result['sensor_cal'] = self.sigan.sensor_calibration_data
+        measurement_result["end_time"] = end_time
+        measurement_result["domain"] = Domain.TIME.value
+        measurement_result["measurement_type"] = MeasurementType.SINGLE_FREQUENCY.value
+        measurement_result["task_id"] = task_id
+        measurement_result["calibration_datetime"] = self.sigan.sensor_calibration_data[
+            "calibration_datetime"
+        ]
+        measurement_result["description"] = self.description
+        measurement_result["sigan_cal"] = self.sigan.sigan_calibration_data
+        measurement_result["sensor_cal"] = self.sigan.sensor_calibration_data
         return measurement_result
 
     def get_sigmf_builder(self, measurement_result: dict) -> SigMFBuilder:
         sigmf_builder = super().get_sigmf_builder(measurement_result)
-        time_domain_annotation = TimeDomainAnnotation(0, self.received_samples)
+        time_domain_annotation = TimeDomainAnnotation(
+            start=0,
+            count=self.received_samples,
+            detector="sample_iq",
+            units="volts",
+            reference="preselector input",
+        )
         sigmf_builder.add_metadata_generator(
             type(time_domain_annotation).__name__, time_domain_annotation
         )

--- a/scos_actions/metadata/annotations/fft_annotation.py
+++ b/scos_actions/metadata/annotations/fft_annotation.py
@@ -3,23 +3,39 @@ from scos_actions.metadata.sigmf_builder import SigMFBuilder
 
 
 class FrequencyDomainDetectionAnnotation(Metadata):
-
-    def __init__(self, detector, start, count):
+    def __init__(
+        self,
+        start: int,
+        count: int,
+        fft_size: int,
+        window: str,
+        enbw: float,
+        detector: str,
+        nffts: int,
+        units: str,
+        reference: str,
+    ):
         super().__init__(start, count)
+        self.fft_size = fft_size
+        self.window = window
+        self.enbw = enbw
         self.detector = detector
+        self.nffts = nffts
+        self.units = units
+        self.reference = reference
 
-    def create_metadata(self, sigmf_builder: SigMFBuilder, measurement_result):
+    def create_metadata(self, sigmf_builder: SigMFBuilder, measurement_result: dict):
         metadata = {
             "ntia-core:annotation_type": "FrequencyDomainDetection",
-            "ntia-algorithm:number_of_samples_in_fft": measurement_result['fft_size'],
-            "ntia-algorithm:window": measurement_result['window'],
-            "ntia-algorithm:equivalent_noise_bandwidth": measurement_result['enbw'],
-            "ntia-algorithm:detector": 'fft_' + self.detector,
-            "ntia-algorithm:number_of_ffts": measurement_result['nffts'],
-            "ntia-algorithm:units": 'dBm',
-            "ntia-algorithm:reference": '"preselector input"',
-            "ntia-algorithm:frequency_start": measurement_result['frequency_start'],
-            "ntia-algorithm:frequency_stop": measurement_result['frequency_stop'],
-            "ntia-algorithm:frequency_step": measurement_result['frequency_step'],
+            "ntia-algorithm:number_of_samples_in_fft": self.fft_size,
+            "ntia-algorithm:window": self.window,
+            "ntia-algorithm:equivalent_noise_bandwidth": self.enbw,
+            "ntia-algorithm:detector": "fft_" + self.detector,
+            "ntia-algorithm:number_of_ffts": self.nffts,
+            "ntia-algorithm:units": self.units,
+            "ntia-algorithm:reference": self.reference,
+            "ntia-algorithm:frequency_start": measurement_result["frequency_start"],
+            "ntia-algorithm:frequency_stop": measurement_result["frequency_stop"],
+            "ntia-algorithm:frequency_step": measurement_result["frequency_step"],
         }
-        sigmf_builder.add_annotation(self.start, measurement_result['fft_size'], metadata)
+        sigmf_builder.add_annotation(self.start, self.fft_size, metadata)

--- a/scos_actions/metadata/annotations/fft_annotation.py
+++ b/scos_actions/metadata/annotations/fft_annotation.py
@@ -14,6 +14,9 @@ class FrequencyDomainDetectionAnnotation(Metadata):
         nffts: int,
         units: str,
         reference: str,
+        frequency_start: float,
+        frequency_stop: float,
+        frequency_step: float,
     ):
         super().__init__(start, count)
         self.fft_size = fft_size
@@ -23,6 +26,9 @@ class FrequencyDomainDetectionAnnotation(Metadata):
         self.nffts = nffts
         self.units = units
         self.reference = reference
+        self.frequency_start = frequency_start
+        self.frequency_stop = frequency_stop
+        self.frequency_step = frequency_step
 
     def create_metadata(self, sigmf_builder: SigMFBuilder, measurement_result: dict):
         metadata = {
@@ -34,8 +40,8 @@ class FrequencyDomainDetectionAnnotation(Metadata):
             "ntia-algorithm:number_of_ffts": self.nffts,
             "ntia-algorithm:units": self.units,
             "ntia-algorithm:reference": self.reference,
-            "ntia-algorithm:frequency_start": measurement_result["frequency_start"],
-            "ntia-algorithm:frequency_stop": measurement_result["frequency_stop"],
-            "ntia-algorithm:frequency_step": measurement_result["frequency_step"],
+            "ntia-algorithm:frequency_start": self.frequency_start,
+            "ntia-algorithm:frequency_stop": self.frequency_stop,
+            "ntia-algorithm:frequency_step": self.frequency_step,
         }
         sigmf_builder.add_annotation(self.start, self.fft_size, metadata)

--- a/scos_actions/metadata/annotations/time_domain_annotation.py
+++ b/scos_actions/metadata/annotations/time_domain_annotation.py
@@ -7,9 +7,9 @@ class TimeDomainAnnotation(Metadata):
         self,
         start: int,
         count: int,
-        detector: str = "sample_iq",
-        units: str = "volts",
-        reference: str = "preselector input",
+        detector: str,
+        units: str,
+        reference: str,
     ):
         super().__init__(start, count)
         self.detector = detector

--- a/scos_actions/metadata/annotations/time_domain_annotation.py
+++ b/scos_actions/metadata/annotations/time_domain_annotation.py
@@ -1,17 +1,27 @@
 from scos_actions.metadata.metadata import Metadata
 from scos_actions.metadata.sigmf_builder import SigMFBuilder
 
+
 class TimeDomainAnnotation(Metadata):
+    def __init__(
+        self,
+        start: int,
+        count: int,
+        detector: str = "sample_iq",
+        units: str = "volts",
+        reference: str = "preselector input",
+    ):
+        super().__init__(start, count)
+        self.detector = detector
+        self.units = units
+        self.reference = reference
 
-    def __init__(self, start, count):
-        super().__init__(start,count)
-
-    def create_metadata(self, sigmf_builder: SigMFBuilder, measurement_result):
-        time_domain_detection_md = {
+    def create_metadata(self, sigmf_builder: SigMFBuilder, measurement_result: dict):
+        metadata = {
             "ntia-core:annotation_type": "TimeDomainDetection",
-            "ntia-algorithm:detector": "sample_iq",
+            "ntia-algorithm:detector": self.detector,
             "ntia-algorithm:number_of_samples": self.count,
-            "ntia-algorithm:units": "volts",
-            "ntia-algorithm:reference": "preselector input",
+            "ntia-algorithm:units": self.units,
+            "ntia-algorithm:reference": self.reference,
         }
-        sigmf_builder.add_annotation(self.start, self.count, time_domain_detection_md)
+        sigmf_builder.add_annotation(self.start, self.count, metadata)


### PR DESCRIPTION
Generalizes `TimeDomainAnnotation` and `FrequencyDomainDetectionAnnotation`.

This extends functionality of `TimeDomainAnnotation` to support time domain captures other than raw IQ captures.

Hard-coded metadata values are removed from the annotation classes so that accurate metadata *must* be supplied by the action. Existing actions `acquire_single_freq_fft` and `acquire_single_freq_time_domain_iq` are updated to reflect the changes. The update to `acquire_single_freq_time_domain_iq` implicitly applies the update to `acquire_stepped_freq_time_domain_iq` as well.

The updates to `FrequencyDomainDetectionAnnotation` make it independent of the `measurement_result`, so that actions are not required to store FFT metadata in the `measurement_result`.