### PR TITLE
Require classification metadata in YAML configs

### DIFF
--- a/scos_actions/actions/acquire_single_freq_fft.py
+++ b/scos_actions/actions/acquire_single_freq_fft.py
@@ -120,6 +120,7 @@ SAMPLE_RATE = "sample_rate"
 NUM_SKIP = "nskip"
 NUM_FFTS = "nffts"
 FFT_SIZE = "fft_size"
+CLASSIFICATION = "classification"
 
 
 class SingleFrequencyFftAcquisition(MeasurementAction):
@@ -149,6 +150,7 @@ class SingleFrequencyFftAcquisition(MeasurementAction):
         self.nffts = get_parameter(NUM_FFTS, self.parameters)
         self.nskip = get_parameter(NUM_SKIP, self.parameters)
         self.frequency_Hz = get_parameter(FREQUENCY, self.parameters)
+        self.classification = get_parameter(CLASSIFICATION, self.parameters)
         # FFT setup
         self.fft_detector = create_power_detector(
             "M4sDetector", ["min", "max", "mean", "median", "sample"]
@@ -188,7 +190,7 @@ class SingleFrequencyFftAcquisition(MeasurementAction):
         measurement_result["measurement_type"] = MeasurementType.SINGLE_FREQUENCY.value
         measurement_result["sigan_cal"] = self.sigan.sigan_calibration_data
         measurement_result["sensor_cal"] = self.sigan.sensor_calibration_data
-        measurement_result["classification"] = "UNCLASSIFIED"
+        measurement_result["classification"] = self.classification
         return measurement_result
 
     def apply_m4s(self, measurement_result: dict) -> ndarray:

--- a/scos_actions/actions/acquire_single_freq_tdomain_iq.py
+++ b/scos_actions/actions/acquire_single_freq_tdomain_iq.py
@@ -49,6 +49,7 @@ FREQUENCY = "frequency"
 SAMPLE_RATE = "sample_rate"
 DURATION_MS = "duration_ms"
 NUM_SKIP = "nskip"
+CLASSIFICATION = "classification"
 
 
 class SingleFrequencyTimeDomainIqAcquisition(MeasurementAction):
@@ -77,6 +78,7 @@ class SingleFrequencyTimeDomainIqAcquisition(MeasurementAction):
         self.nskip = get_parameter(NUM_SKIP, self.parameters)
         self.duration_ms = get_parameter(DURATION_MS, self.parameters)
         self.frequency_Hz = get_parameter(FREQUENCY, self.parameters)
+        self.classification = get_parameter(CLASSIFICATION, self.parameters)
 
     def execute(self, schedule_entry, task_id) -> dict:
         start_time = utils.get_datetime_str_now()
@@ -97,7 +99,7 @@ class SingleFrequencyTimeDomainIqAcquisition(MeasurementAction):
         measurement_result["description"] = self.description
         measurement_result["sigan_cal"] = self.sigan.sigan_calibration_data
         measurement_result["sensor_cal"] = self.sigan.sensor_calibration_data
-        measurement_result["classification"] = "UNCLASSIFIED"
+        measurement_result["classification"] = self.classification
         return measurement_result
 
     def get_sigmf_builder(self, measurement_result: dict) -> SigMFBuilder:

--- a/scos_actions/actions/acquire_stepped_freq_tdomain_iq.py
+++ b/scos_actions/actions/acquire_stepped_freq_tdomain_iq.py
@@ -41,6 +41,9 @@ import numpy as np
 
 from scos_actions import utils
 from scos_actions.actions.acquire_single_freq_tdomain_iq import (
+    DURATION_MS,
+    FREQUENCY,
+    NUM_SKIP,
     SingleFrequencyTimeDomainIqAcquisition,
 )
 from scos_actions.actions.interfaces.signals import measurement_action_completed
@@ -49,12 +52,6 @@ from scos_actions.metadata.sigmf_builder import Domain, MeasurementType
 from scos_actions.utils import get_parameter
 
 logger = logging.getLogger(__name__)
-
-# Define parameter keys
-FREQUENCY = "frequency"
-SAMPLE_RATE = "sample_rate"
-DURATION_MS = "duration_ms"
-NUM_SKIP = "nskip"
 
 
 class SteppedFrequencyTimeDomainIqAcquisition(SingleFrequencyTimeDomainIqAcquisition):
@@ -115,7 +112,7 @@ class SteppedFrequencyTimeDomainIqAcquisition(SingleFrequencyTimeDomainIqAcquisi
             measurement_result["name"] = self.name
             measurement_result["sigan_cal"] = self.sigan.sigan_calibration_data
             measurement_result["sensor_cal"] = self.sigan.sensor_calibration_data
-            measurement_result["classification"] = "UNCLASSIFIED"
+            measurement_result["classification"] = self.classification
             sigmf_builder = self.get_sigmf_builder(measurement_result)
             self.create_metadata(
                 sigmf_builder, schedule_entry_json, measurement_result, recording_id

--- a/scos_actions/configs/actions/test_multi_frequency_iq_action.yml
+++ b/scos_actions/configs/actions/test_multi_frequency_iq_action.yml
@@ -15,3 +15,4 @@ stepped_frequency_time_domain_iq:
   sample_rate: 15.36e6
   duration_ms: 80
   nskip: 15.36e4
+  classification: UNCLASSIFIED

--- a/scos_actions/configs/actions/test_single_frequency_iq_action.yml
+++ b/scos_actions/configs/actions/test_single_frequency_iq_action.yml
@@ -5,3 +5,4 @@ single_frequency_time_domain_iq:
   sample_rate: 15.36e6
   duration_ms: 1000
   nskip: 15.36e4
+  classification: UNCLASSIFIED

--- a/scos_actions/configs/actions/test_single_frequency_m4s_action.yml
+++ b/scos_actions/configs/actions/test_single_frequency_m4s_action.yml
@@ -6,3 +6,4 @@ single_frequency_fft:
   fft_size: 1024
   nffts: 300
   nskip: 15.36e4
+  classification: UNCLASSIFIED


### PR DESCRIPTION
Addresses #41 by requiring action configs to specify the classification status of the data the action will produce. This value will be written to the SigMF `ntia-core` [Measurement Object](https://github.com/NTIA/sigmf-ns-ntia/blob/master/ntia-core.sigmf-ext.md#11-measurement-object) in the metadata produced by the action.

Existing action configs will need to be updated to avoid errors, since time domain IQ actions and the M4S FFT action now both require a value for `classification` in their configs. Y-Factor action configs do not require a `classification` value, since they do not save SigMF metadata.

Previously, results from these actions had no `classification` recorded in their metadata results, despite this technically being a required key according to the `ntia-core` specification. Since #32, `classification` has been hard-coded as `UNCLASSIFIED`. 