### PR TITLE
Add methods for power cycling in SignalAnalyzerInterface

### DIFF
--- a/scos_actions/hardware/sigan_iface.py
+++ b/scos_actions/hardware/sigan_iface.py
@@ -1,13 +1,21 @@
 import copy
+import logging
+import time
 from abc import ABC, abstractmethod
 
 from scos_actions.calibration import sensor_calibration, sigan_calibration
 from scos_actions.calibration.calibration import Calibration
 from scos_actions.capabilities import capabilities
+from scos_actions.hardware.hardware_configuration_exception import (
+    HardwareConfigurationException,
+)
+from scos_actions.hardware.utils import power_cycle_sigan
 from scos_actions.utils import (
     convert_string_to_millisecond_iso_format,
     get_datetime_str_now,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class SignalAnalyzerInterface(ABC):
@@ -66,11 +74,42 @@ class SignalAnalyzerInterface(ABC):
         """
         pass
 
+    @abstractmethod
+    def connect(self) -> None:
+        """
+        Establish a connection to the signal analyzer.
+        """
+        pass
+
     @property
     @abstractmethod
     def healthy(self) -> bool:
         """Perform a health check by collecting IQ samples."""
         pass
+
+    def power_cycle_and_connect(self, sleep_time: float = 2.0) -> None:
+        """
+        Attempt to cycle signal analyzer power then reconnect.
+
+        :param sleep_time: Time (s) to wait for power to cycle, defaults to 2.0
+        """
+        logger.info("Attempting to power cycle the signal analyzer and reconnect.")
+        try:
+            power_cycle_sigan()
+        except HardwareConfigurationException as hce:
+            logger.warn(f"Unable to power cycle sigan: {hce}")
+            return
+        try:
+            # Wait for power cycle to complete
+            logger.debug(f"Waiting {sleep_time} seconds before reconnecting...")
+            time.sleep(sleep_time)
+            logger.info("Power cycled signal analyzer. Reconnecting...")
+            self.connect()
+        except Exception as e:
+            logger.error(
+                f"Unable to reconnect to signal analyzer after power cycling: {e}"
+            )
+        return
 
     def recompute_calibration_data(self, cal_args: Calibration) -> None:
         """Set the calibration data based on the current tuning"""


### PR DESCRIPTION
- Add an `@abstractmethod` `connect` which must be implemented by signal analyzer plugins (this is already implemented by `scos-tekrsa`, `scos-usrp`, and `scos-keysight`)
- Add a class method `power_cycle_and_connect` which calls `scos_actions.hardware.utils.power_cycle_sigan`, waits for (by default) 2 seconds, then attempts to connect to the signal analyzer