### PR TITLE
Add failure recovery to calibration action

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: python3.8
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-ast
         types: [file, python]
@@ -18,25 +18,30 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.2
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
         args: ["--py3-plus"]
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
       - id: isort
         name: isort (python)
         types: [file, python]
         args: ["--profile", "black", "--filter-files", "--gitignore"]
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
         types: [file, python]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.32.2
+    rev: v0.33.0
     hooks:
       - id: markdownlint
         types: [file, markdown]
         exclude: GitHubRepoPublicReleaseApproval.md|LICENSE.md
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.4
+    hooks:
+    - id: bandit
+      exclude: ^tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,8 +40,3 @@ repos:
       - id: markdownlint
         types: [file, markdown]
         exclude: GitHubRepoPublicReleaseApproval.md|LICENSE.md
-  - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.4
-    hooks:
-    - id: bandit
-      exclude: ^tests/

--- a/scos_actions/actions/calibrate_y_factor.py
+++ b/scos_actions/actions/calibrate_y_factor.py
@@ -400,4 +400,4 @@ class YFactorCalibration(Action):
             msg = "acquisition failed: signal analyzer required but not available"
             raise RuntimeError(msg)
         if not self.sigan.healthy():
-            trigger_api_restart.send(sensor=self.__class__)
+            trigger_api_restart.send(sender=self.__class__)

--- a/scos_actions/actions/calibrate_y_factor.py
+++ b/scos_actions/actions/calibrate_y_factor.py
@@ -95,6 +95,7 @@ from scos_actions.signal_processing.power_analysis import (
     create_power_detector,
 )
 from scos_actions.signal_processing.unit_conversion import convert_watts_to_dBm
+from scos_actions.signals import trigger_api_restart
 from scos_actions.utils import ParameterException, get_parameter
 
 logger = logging.getLogger(__name__)
@@ -398,3 +399,5 @@ class YFactorCalibration(Action):
         if not self.sigan.is_available:
             msg = "acquisition failed: signal analyzer required but not available"
             raise RuntimeError(msg)
+        if not self.sigan.healthy():
+            trigger_api_restart.send(sensor=self.__class__)

--- a/scos_actions/actions/interfaces/action.py
+++ b/scos_actions/actions/interfaces/action.py
@@ -38,7 +38,10 @@ class Action(ABC):
         self.sigan = sigan
         self.gps = gps
         self.sensor_definition = capabilities["sensor"]
-        if "preselector" in self.sensor_definition and "rf_paths" in self.sensor_definition["preselector"]:
+        if (
+            "preselector" in self.sensor_definition
+            and "rf_paths" in self.sensor_definition["preselector"]
+        ):
             self.has_configurable_preselector = True
         else:
             self.has_configurable_preselector = False

--- a/scos_actions/calibration/calibration.py
+++ b/scos_actions/calibration/calibration.py
@@ -83,9 +83,12 @@ def load_from_json(fname):
     with open(fname) as file:
         calibration = json.load(file)
     # Check that the required fields are in the dict
-    assert "calibration_datetime" in calibration
-    assert "calibration_data" in calibration
-    assert "clock_rate_lookup_by_sample_rate" in calibration
+    if not calibration.keys() >= {
+        "calibration_datetime",
+        "calibration_data",
+        "clock_rate_lookup_by_sample_rate",
+    }:
+        raise Exception("Loaded calibration dictionary is missing required fields.")
     calibration_data = convert_keys(calibration["calibration_data"])
     # Create and return the Calibration object
     return Calibration(

--- a/scos_actions/metadata/sigmf_builder.py
+++ b/scos_actions/metadata/sigmf_builder.py
@@ -157,7 +157,8 @@ class SigMFBuilder:
             "core:datetime": capture_time,
         }
         # Add extra information to capture
-        if extra_entries: capture_md.update(extra_entries)
+        if extra_entries:
+            capture_md.update(extra_entries)
 
         self.sigmf_md.add_capture(sample_start, metadata=capture_md)
 


### PR DESCRIPTION
- Update calibration action's `test_required_components` to trigger API container restart if the sigan is not healthy, in the same way that the SEA data product action currently does (as of #60 )
- Update and re-run pre-commit hooks

Misconfigured preselector values (preselector sensor index, preselector RF path names) will raise exceptions when the calibration action is run. This is the desired behavior, since this is the result of a bad config file, and not the result of an error state being reached during sensor deployment. Therefore, no modifications are made to `test_required_components` to address bad configurations.

Merging this PR closes #63 