### PR TITLE
Require django >= 3.2.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 
 dependencies = [
     "environs>=9.5.0",
-    "django>=3.2.15,<4.0",
+    "django>=3.2.17,<4.0",
     "its_preselector @ git+https://github.com/NTIA/Preselector@3.0.1",
     "numexpr>=2.8.3",
     "numpy>=1.22.0",


### PR DESCRIPTION
- Require `django>=3.2.17` to include the patch for GHSA-q2jf-h9jm-m7p4