### PR TITLE
Fix operand array error

### DIFF
--- a/scos_actions/signal_processing/fft.py
+++ b/scos_actions/signal_processing/fft.py
@@ -86,16 +86,18 @@ def get_fft(
 
     # Resize time data for FFTs
     time_data = np.reshape(time_data[: num_ffts * fft_size], (num_ffts, fft_size))
-    out_data = np.empty(time_data.shape, dtype=time_data.dtype)
     # Apply the FFT window if provided
     if fft_window is not None:
         if time_data.size > NUMEXPR_THRESHOLD:
-            ne.evaluate("time_data*fft_window", out=out_data, casting="same_kind")
+            time_data = (
+                time_data.copy()
+            )  # Avoids operand array error on read-only input data
+            ne.evaluate("time_data*fft_window", out=time_data, casting="same_kind")
         else:
-            out_data = time_data * fft_window
+            time_data *= fft_window
 
     # Take the FFT
-    complex_fft = sp_fft(out_data, norm=norm, workers=workers)
+    complex_fft = sp_fft(time_data, norm=norm, workers=workers)
 
     # Shift the frequencies if desired
     if shift:

--- a/scos_actions/signal_processing/fft.py
+++ b/scos_actions/signal_processing/fft.py
@@ -86,16 +86,16 @@ def get_fft(
 
     # Resize time data for FFTs
     time_data = np.reshape(time_data[: num_ffts * fft_size], (num_ffts, fft_size))
-
+    out_data = np.empty(len(time_data))
     # Apply the FFT window if provided
     if fft_window is not None:
         if time_data.size > NUMEXPR_THRESHOLD:
-            ne.evaluate("time_data*fft_window", out=time_data, casting="same_kind")
+            ne.evaluate("time_data*fft_window", out=out_data, casting="same_kind")
         else:
-            time_data *= fft_window
+            out_data = time_data * fft_window
 
     # Take the FFT
-    complex_fft = sp_fft(time_data, norm=norm, workers=workers)
+    complex_fft = sp_fft(out_data, norm=norm, workers=workers)
 
     # Shift the frequencies if desired
     if shift:

--- a/scos_actions/signal_processing/fft.py
+++ b/scos_actions/signal_processing/fft.py
@@ -86,7 +86,7 @@ def get_fft(
 
     # Resize time data for FFTs
     time_data = np.reshape(time_data[: num_ffts * fft_size], (num_ffts, fft_size))
-    out_data = np.empty(len(time_data))
+    out_data = np.empty(time_data.shape)
     # Apply the FFT window if provided
     if fft_window is not None:
         if time_data.size > NUMEXPR_THRESHOLD:

--- a/scos_actions/signal_processing/fft.py
+++ b/scos_actions/signal_processing/fft.py
@@ -86,7 +86,7 @@ def get_fft(
 
     # Resize time data for FFTs
     time_data = np.reshape(time_data[: num_ffts * fft_size], (num_ffts, fft_size))
-    out_data = np.empty(time_data.shape)
+    out_data = np.empty(time_data.shape, dtype=time_data.dtype)
     # Apply the FFT window if provided
     if fft_window is not None:
         if time_data.size > NUMEXPR_THRESHOLD:

--- a/scos_actions/signal_processing/tests/test_apd.py
+++ b/scos_actions/signal_processing/tests/test_apd.py
@@ -1,8 +1,10 @@
+import itertools
+
 import numexpr as ne
 import numpy as np
 import pytest
 
-from scos_actions.signal_processing import apd
+from scos_actions.signal_processing import NUMEXPR_THRESHOLD, apd
 
 rng = np.random.default_rng()
 
@@ -20,6 +22,14 @@ def example_iq_data():
     return samps
 
 
+@pytest.fixture
+def example_large_iq_data():
+    n_samps = NUMEXPR_THRESHOLD + 1
+    std_dev = np.sqrt(2) / 2.0
+    samps = rng.normal(0, std_dev, n_samps) + 1j * rng.normal(0, std_dev, n_samps)
+    return samps
+
+
 def test_get_apd_nan_handling():
     # All zero amplitudes should be converted to NaN
     # Peak amplitude 0 count should be replaced with NaN
@@ -29,15 +39,20 @@ def test_get_apd_nan_handling():
     assert all(np.isnan(a))
 
 
-def test_get_apd_no_downsample(example_iq_data):
+def test_get_apd_no_downsample(example_iq_data, example_large_iq_data):
     bin_sizes = [None, 0]
+    immutable = [True, False]
     impedance = 50
-    for bin_size in bin_sizes:
-        apd_result = apd.get_apd(example_iq_data, bin_size)
+    for bin_size, readonly, iq in itertools.product(
+        bin_sizes, immutable, (example_iq_data, example_large_iq_data)
+    ):
+        if readonly:
+            iq.setflags(write=False)
+        apd_result = apd.get_apd(iq, bin_size)
         assert isinstance(apd_result, tuple)
         assert len(apd_result) == 2
         assert all(isinstance(x, np.ndarray) for x in apd_result)
-        assert all(len(x) == len(example_iq_data) for x in apd_result)
+        assert all(len(x) == len(iq) for x in apd_result)
         p, a = apd_result
         assert not any(x == 0 for x in a)
         np.testing.assert_equal(a, np.real(a))
@@ -47,20 +62,23 @@ def test_get_apd_no_downsample(example_iq_data):
         assert all(p[i + 1] <= p[i] for i in range(len(p) - 2))
         assert np.isnan(p[-1])
         # Check against version with impedance provided
-        scaled_p, scaled_a = apd.get_apd(
-            example_iq_data, bin_size, impedance_ohms=impedance
-        )
+        scaled_p, scaled_a = apd.get_apd(iq, bin_size, impedance_ohms=impedance)
         np.testing.assert_allclose(a - 10.0 * np.log10(impedance), scaled_a)
         np.testing.assert_array_equal(p, scaled_p)
 
 
-def test_get_apd_downsample(example_iq_data):
+def test_get_apd_downsample(example_iq_data, example_large_iq_data):
     with pytest.raises(ValueError):
         _ = apd.get_apd(example_iq_data, 0.5, 100, 99)
     with pytest.raises(ValueError):
         _ = apd.get_apd(example_iq_data, 1.0, 90, 100.6)
     bin_sizes = [1.0, 0.5, 0.25]
-    for bin_size in bin_sizes:
+    immutable = [True, False]
+    for bin_size, readonly, iq in itertools.product(
+        bin_sizes, immutable, (example_iq_data, example_large_iq_data)
+    ):
+        if readonly:
+            iq.setflags(write=False)
         min_bin = np.nanmin(ne.evaluate("20*log10(abs(example_iq_data).real)"))
         max_bin = np.nanmax(ne.evaluate("20*log10(abs(example_iq_data).real)"))
         p, a = apd.get_apd(example_iq_data, bin_size, round(min_bin), round(max_bin))

--- a/scos_actions/signal_processing/tests/test_apd.py
+++ b/scos_actions/signal_processing/tests/test_apd.py
@@ -79,11 +79,11 @@ def test_get_apd_downsample(example_iq_data, example_large_iq_data):
     ):
         if readonly:
             iq.setflags(write=False)
-        min_bin = np.nanmin(ne.evaluate("20*log10(abs(example_iq_data).real)"))
-        max_bin = np.nanmax(ne.evaluate("20*log10(abs(example_iq_data).real)"))
-        p, a = apd.get_apd(example_iq_data, bin_size, round(min_bin), round(max_bin))
+        min_bin = np.nanmin(ne.evaluate("20*log10(abs(iq).real)"))
+        max_bin = np.nanmax(ne.evaluate("20*log10(abs(iq).real)"))
+        p, a = apd.get_apd(iq, bin_size, round(min_bin), round(max_bin))
         assert len(p) == len(a)
-        assert len(p) < len(example_iq_data)
+        assert len(p) < len(iq)
         np.testing.assert_equal(a, np.real(a))
         assert all(a[i] <= a[i + 1] for i in range(len(a) - 1))
         np.testing.assert_allclose(np.diff(a), np.ones(len(a) - 1) * bin_size)

--- a/scos_actions/signal_processing/tests/test_power_analysis.py
+++ b/scos_actions/signal_processing/tests/test_power_analysis.py
@@ -19,6 +19,13 @@ def large_array():
 
 
 @pytest.fixture
+def large_readonly_array():
+    x = np.ones(NUMEXPR_THRESHOLD * 2) * TEST_VAL_CPLX
+    x.setflags(write=False)
+    return x
+
+
+@pytest.fixture
 def small_array():
     return np.ones(NUMEXPR_THRESHOLD // 2) * TEST_VAL_CPLX
 
@@ -44,8 +51,8 @@ def true_scalars(complex_scalar, real_scalar):
 
 
 @pytest.fixture
-def all_arrays(large_array, small_array, scalar_array):
-    return [large_array, small_array, scalar_array]
+def all_arrays(large_array, small_array, scalar_array, large_readonly_array):
+    return [large_array, small_array, scalar_array, large_readonly_array]
 
 
 def test_calculate_power_watts(all_arrays, true_scalars):

--- a/scos_actions/signal_processing/tests/test_unit_conversion.py
+++ b/scos_actions/signal_processing/tests/test_unit_conversion.py
@@ -37,6 +37,9 @@ def test_convert_watts_to_dBm(small_array_len):
             test_convert(int(v), c)
         test_convert(np.ones(small_array_len) * v, c)
         test_convert(np.ones(NUMEXPR_THRESHOLD) * v, c)
+        large_readonly = np.ones(NUMEXPR_THRESHOLD) * v
+        large_readonly.setflags(write=False)
+        test_convert(large_readonly, c)
 
 
 def test_convert_dBm_to_watts(small_array_len):
@@ -58,6 +61,9 @@ def test_convert_dBm_to_watts(small_array_len):
             test_convert(int(v), c)
         test_convert(np.ones(small_array_len) * v, c)
         test_convert(np.ones(NUMEXPR_THRESHOLD) * v, c)
+        large_readonly = np.ones(NUMEXPR_THRESHOLD) * v
+        large_readonly.setflags(write=False)
+        test_convert(large_readonly, c)
 
 
 def test_convert_linear_to_dB(small_array_len):
@@ -79,6 +85,9 @@ def test_convert_linear_to_dB(small_array_len):
             test_convert(int(v), c)
         test_convert(np.ones(small_array_len) * v, c)
         test_convert(np.ones(NUMEXPR_THRESHOLD) * v, c)
+        large_readonly = np.ones(NUMEXPR_THRESHOLD) * v
+        large_readonly.setflags(write=False)
+        test_convert(large_readonly, c)
 
 
 def test_convert_dB_to_linear(small_array_len):
@@ -100,6 +109,9 @@ def test_convert_dB_to_linear(small_array_len):
             test_convert(int(v), c)
         test_convert(np.ones(small_array_len) * v, c)
         test_convert(np.ones(NUMEXPR_THRESHOLD) * v, c)
+        large_readonly = np.ones(NUMEXPR_THRESHOLD) * v
+        large_readonly.setflags(write=False)
+        test_convert(large_readonly, c)
 
 
 def test_convert_kelvins_to_celsius(small_array_len):


### PR DESCRIPTION
This fixes a bug caused by passing in a read only array into the fft routine. The fix creates a new empty array for the output that matches the shape and datatype of the array passed in.  