### PR TITLE
Use multiple Ray supervisor actors to process IQ in SEA action

### DIFF
--- a/scos_actions/actions/acquire_sea_data_product.py
+++ b/scos_actions/actions/acquire_sea_data_product.py
@@ -429,7 +429,6 @@ class IQProcessor:
         # Do not wait until they finish. Yield references to their results.
         yield [worker.run.remote(iqdata) for worker in self.workers]
         del iqdata
-        gc.collect()
 
 
 class NasctnSeaDataProduct(Action):

--- a/scos_actions/actions/acquire_sea_data_product.py
+++ b/scos_actions/actions/acquire_sea_data_product.py
@@ -517,10 +517,10 @@ class NasctnSeaDataProduct(Action):
         # Initialize remote supervisor actors for IQ processing
         tic = perf_counter()
         # This uses iteration_params[0] because
-        iq_processors = (
+        iq_processors = [
             IQProcessor.remote(self.iteration_params[0], self.iir_sos)
             for _ in range(NUM_ACTORS)
-        )
+        ]
         toc = perf_counter()
         logger.debug(f"Spawned {NUM_ACTORS} supervisor actors in {toc-tic:.2f} s")
 

--- a/scos_actions/actions/acquire_sea_data_product.py
+++ b/scos_actions/actions/acquire_sea_data_product.py
@@ -516,12 +516,15 @@ class NasctnSeaDataProduct(Action):
         # Collect all IQ data and spawn data product computation processes
         dp_procs, cpu_speed = [], []
         capture_tic = perf_counter()
-        iq_processor = IQProcessor.remote(self.iteration_params[0], self.iir_sos)
         for i, parameters in enumerate(self.iteration_params):
             measurement_result = self.capture_iq(parameters)
             # Start data product processing but do not block next IQ capture
             tic = perf_counter()
-            dp_procs.append(iq_processor.run.remote(measurement_result["data"]))
+            dp_procs.append(
+                IQProcessor.remote(parameters, self.iir_sos).run.remote(
+                    measurement_result["data"]
+                )
+            )
             del measurement_result["data"]
             toc = perf_counter()
             logger.debug(f"IQ data delivered for processing in {toc-tic:.2f} s")
@@ -563,7 +566,7 @@ class NasctnSeaDataProduct(Action):
             logger.debug(f"Waited {toc-tic} s for channel data")
             all_data.extend(NasctnSeaDataProduct.transform_data(channel_data))
         result_toc = perf_counter()
-        del dp_procs, iq_processor, channel_data, channel_data_refs
+        del dp_procs, channel_data, channel_data_refs
         logger.debug(f"Got all processed data in {result_toc-result_tic:.2f} s")
 
         # Build metadata and convert data to compressed bytes

--- a/scos_actions/actions/acquire_sea_data_product.py
+++ b/scos_actions/actions/acquire_sea_data_product.py
@@ -575,7 +575,8 @@ class NasctnSeaDataProduct(Action):
             toc = perf_counter()
             logger.debug(f"Waited {toc-tic} s for channel data")
             all_data.extend(NasctnSeaDataProduct.transform_data(channel_data))
-            ray.kill(iq_processors[self.iteration_params[i][FREQUENCY]])
+        for ray_actor in iq_processors:
+            ray.kill(ray_actor)
         result_toc = perf_counter()
         del dp_procs, iq_processors, channel_data, channel_data_refs
         logger.debug(f"Got all processed data in {result_toc-result_tic:.2f} s")

--- a/scos_actions/actions/acquire_sea_data_product.py
+++ b/scos_actions/actions/acquire_sea_data_product.py
@@ -551,7 +551,7 @@ class NasctnSeaDataProduct(Action):
         # Collect processed data product results
         all_data, max_max_ch_pwrs, med_mean_ch_pwrs = [], [], []
         result_tic = perf_counter()
-        for channel_data_process in dp_procs:
+        for i, channel_data_process in enumerate(dp_procs):
             # Retrieve object references for channel data
             channel_data_refs = ray.get(channel_data_process)
             channel_data = []
@@ -574,6 +574,7 @@ class NasctnSeaDataProduct(Action):
             toc = perf_counter()
             logger.debug(f"Waited {toc-tic} s for channel data")
             all_data.extend(NasctnSeaDataProduct.transform_data(channel_data))
+            ray.kill(iq_processors[self.iteration_params[i][FREQUENCY]])
         result_toc = perf_counter()
         del dp_procs, iq_processors, channel_data, channel_data_refs
         logger.debug(f"Got all processed data in {result_toc-result_tic:.2f} s")

--- a/scos_actions/actions/acquire_sea_data_product.py
+++ b/scos_actions/actions/acquire_sea_data_product.py
@@ -565,7 +565,6 @@ class NasctnSeaDataProduct(Action):
             all_data.extend(NasctnSeaDataProduct.transform_data(channel_data))
         result_toc = perf_counter()
         del dp_procs, iq_processor, channel_data, channel_data_refs
-        gc.collect()
         logger.debug(f"Got all processed data in {result_toc-result_tic:.2f} s")
 
         # Build metadata and convert data to compressed bytes


### PR DESCRIPTION
This PR increases the number of Ray supervisor actors used for IQ processing in the SEA data product action, from 1 to 3. It also adds code which explicitly kills the actors after retrieving processed data. Manual garbage collection calls are also removed, which may have been causing issues when running in separate processes.

In testing (on seadog02), this has reduced the failure rate for the action runs. Without this patch, the failure rate is 20% on average. With this patch, the error rate is 8.5% on average. Segmentation faults and OverflowError still occur and should be addressed in the future.

Negligible impact has been observed on CPU usage, memory usage, and action runtime.