### PR TITLE
Fix DigitalFilter metadata struct description type

### DIFF
--- a/scos_actions/metadata/structs/ntia_algorithm.py
+++ b/scos_actions/metadata/structs/ntia_algorithm.py
@@ -36,7 +36,7 @@ class DigitalFilter(msgspec.Struct, **SIGMF_OBJECT_KWARGS):
     feedback_coefficients: Optional[List[float]] = None
     attenuation_cutoff: Optional[float] = None
     frequency_cutoff: Optional[float] = None
-    description: Optional[float] = None
+    description: Optional[str] = None
 
 
 class Graph(msgspec.Struct, **SIGMF_OBJECT_KWARGS):


### PR DESCRIPTION
Type of description was incorrectly "float" instead of "string"

This doesn't cause any errors when encoding, but does cause errors if trying to use this struct in a third party application to decode metadata JSON.