### PR TITLE
Remove unused iteration variable in SEA action

### DIFF
--- a/scos_actions/actions/acquire_sea_data_product.py
+++ b/scos_actions/actions/acquire_sea_data_product.py
@@ -575,7 +575,7 @@ class NasctnSeaDataProduct(Action):
             [],
         )
         result_tic = perf_counter()
-        for i, channel_data_process in enumerate(dp_procs):
+        for channel_data_process in dp_procs:
             # Retrieve object references for channel data
             channel_data_refs = ray.get(channel_data_process)
             channel_data = []


### PR DESCRIPTION
Naming of the loop variable `i` is the same as the inner loop. The outer loop variable is unused, so this causes no problems, but is confusing and should be removed to avoid causing a problem if it were used in the future.