### PR TITLE
Remove divisions from example calibration files

### DIFF
--- a/scos_actions/configs/sensor_calibration_example.json
+++ b/scos_actions/configs/sensor_calibration_example.json
@@ -78,7 +78,6 @@
         }
     },
     "last_calibration_datetime": "1970-01-01T00:00:00.000000Z",
-    "calibration_frequency_divisions": [],
     "calibration_parameters": [
         "sample_rate",
         "frequency",

--- a/scos_actions/configs/sigan_calibration_example.json
+++ b/scos_actions/configs/sigan_calibration_example.json
@@ -78,7 +78,6 @@
         }
     },
     "last_calibration_datetime": "1970-01-01T00:00:00.000000Z",
-    "calibration_frequency_divisions": [],
     "calibration_parameters": [
         "sample_rate",
         "frequency",


### PR DESCRIPTION
Fixes #94 by modifying the example calibration files. The divisions are already unused in scos-actions and scos-sensor, so this is just the final cleanup for removing the remnants of divisions being recorded in calibration JSON files.